### PR TITLE
build run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,38 +9,58 @@ with the following features that are meant to be refactored:
 - A managed resource controller that reconciles `MyType` objects and simply
   prints their configuration in its `Observe` method.
 
+
 ## Developing
 
-Run against a Kubernetes cluster:
+### Prerequisites
 
-```console
-make run
+- Linux/Unix development environment
+
+- Install Confluent CLI:
+
+> Note: Run the following commands in Bash
+
+```
+curl -sL --http1.1 https://cnfl.io/cli | sh -s -- -b /usr/local/bin <Confluent_CLI_Version>
 ```
 
-Build, push, and install:
+Replace <Confluent_CLI_Version> with the correct version in the docker image /cluster/images/provider-confluent-controller/Dockerfile
 
+- Define .env file using example
+
+### Additional recommended steps
+- Install [direnv](https://direnv.net/)
+- Install [Minikube](https://minikube.sigs.k8s.io/)
+
+
+### Running local development
+
+Running the Confluent provider in local development environment can be either be using manual steps or automated steps.
+The automated steps can be followed only when the additional recommend tools have been installed from the previous section.
+
+Manual steps:
+1) Make sure that you have access to a Kubernetes cluster and the correct context is used for Kubectl.
+
+2) Ensure the list of environment variables in the .env file is exported
+3) Run this command:
 ```console
-make all
+make dev
 ```
+This will build and run the confluent provider go code inside the configured Kubernetes cluster
+Automated steps:
+1) Run the script from this path ./scripts/setup.sh
+This will do the followings:
+- Start a Minikube instance and
+- setup Crossplane and
+- configure the required ProviderConfig for Confluent provider.
 
-Build image:
-
+2) Execute this command:
 ```console
-make image
+make dev
 ```
+This will build and run the confluent provider go code inside the configured Minikube cluster
 
-Push image:
-
-```console
-make push
-```
-
-Build binary:
-
-```console
-make build
-```
-
+View the available make commands in the Makefile
 
 ## Useful commands
 
@@ -55,3 +75,6 @@ Want to skip lint during a `make build`?
 ```shell
 make build nolint=1
 ```
+
+
+


### PR DESCRIPTION
This will add the missing instructions for building and running the provider code in dev environment